### PR TITLE
Add softmax and KL divergence to classification loss

### DIFF
--- a/src/CNN/Classification.java
+++ b/src/CNN/Classification.java
@@ -1,12 +1,69 @@
 package CNN;
 
-public class Classification implements Model{
-	
-	/**
-	 * implement the loss function as Cross Entropy Loss
-	 */
-	@Override
-	public double lossFunc() {
-		return 0.0;
-	}
+public class Classification implements Model {
+
+    /**
+     * Applies the softmax function to the given logits.
+     *
+     * @param logits raw output scores from the network
+     * @return probability distribution
+     */
+    private static double[] softmax(double[] logits) {
+        double max = logits[0];
+        for (int i = 1; i < logits.length; i++) {
+            if (logits[i] > max) {
+                max = logits[i];
+            }
+        }
+
+        double[] probs = new double[logits.length];
+        double sum = 0.0;
+        for (int i = 0; i < logits.length; i++) {
+            probs[i] = Math.exp(logits[i] - max);
+            sum += probs[i];
+        }
+        for (int i = 0; i < probs.length; i++) {
+            probs[i] /= sum;
+        }
+        return probs;
+    }
+
+    /**
+     * Computes cross entropy between a predicted probability distribution and
+     * the target distribution.
+     */
+    private static double crossEntropy(double[] probs, double[] target) {
+        double ce = 0.0;
+        for (int i = 0; i < probs.length; i++) {
+            double p = Math.max(Math.min(probs[i], 1.0 - 1e-15), 1e-15);
+            ce -= target[i] * Math.log(p);
+        }
+        return ce;
+    }
+
+    /**
+     * Computes the Kullback–Leibler divergence between two probability
+     * distributions.
+     */
+    private static double klDivergence(double[] probs, double[] target) {
+        double kl = 0.0;
+        for (int i = 0; i < probs.length; i++) {
+            double t = Math.max(Math.min(target[i], 1.0 - 1e-15), 1e-15);
+            double p = Math.max(Math.min(probs[i], 1.0 - 1e-15), 1e-15);
+            kl += t * Math.log(t / p);
+        }
+        return kl;
+    }
+
+    /**
+     * Computes a combined loss consisting of cross entropy and KL divergence
+     * for classification tasks.
+     */
+    @Override
+    public double lossFunc(double[] predicted, double[] target) {
+        double[] probs = softmax(predicted);
+        double ce = crossEntropy(probs, target);
+        double kl = klDivergence(probs, target);
+        return ce + kl;
+    }
 }

--- a/src/CNN/Model.java
+++ b/src/CNN/Model.java
@@ -5,8 +5,14 @@ package CNN;
  */
 public interface Model {
 	
-	/**
-     * Applies the loss function to the supplied value.
+    /**
+     * Computes the loss between the predicted values and the expected
+     * values. Implementations may calculate different loss metrics
+     * (e.g. mean squared error or cross entropy).
+     *
+     * @param predicted values predicted by the network
+     * @param target    the ground truth values
+     * @return computed loss
      */
-	public double lossFunc();
+    double lossFunc(double[] predicted, double[] target);
 }

--- a/src/CNN/Regression.java
+++ b/src/CNN/Regression.java
@@ -1,12 +1,17 @@
 package CNN;
 
-public class Regression implements Model{
-	
-	/**
-	 * implement the loss function as Min Square Loss
-	 */
-	@Override
-	public double lossFunc() {
-		return 0.0;
-	}
+public class Regression implements Model {
+
+    /**
+     * Computes the mean squared error between predicted and target values.
+     */
+    @Override
+    public double lossFunc(double[] predicted, double[] target) {
+        double sum = 0.0;
+        for (int i = 0; i < predicted.length; i++) {
+            double diff = predicted[i] - target[i];
+            sum += diff * diff;
+        }
+        return sum / predicted.length;
+    }
 }


### PR DESCRIPTION
## Summary
- refactor `Classification.lossFunc` to use helper methods
- implement `softmax` for stable probability computation
- add `crossEntropy` and `klDivergence` helpers
- compute classification loss as the sum of cross entropy and KL divergence

## Testing
- `javac src/CNN/*.java`


------
https://chatgpt.com/codex/tasks/task_e_685c1d2653cc83279bc281abf2f9d832