### PR TITLE
Implement input missmatch exception

### DIFF
--- a/src/CNN/InputSizeMissmatchException.java
+++ b/src/CNN/InputSizeMissmatchException.java
@@ -1,5 +1,34 @@
 package CNN;
 
-public class InputSizeMissmatchException {
+/**
+ * Thrown to indicate that an operation received an input
+ * array whose length does not match the expected size.
+ */
+public class InputSizeMissmatchException extends RuntimeException {
 
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public InputSizeMissmatchException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception describing the expected and actual sizes.
+     *
+     * @param expected the expected input length
+     * @param actual   the provided input length
+     */
+    public InputSizeMissmatchException(int expected, int actual) {
+        super("Expected input size " + expected + " but got " + actual);
+    }
+
+    /**
+     * Constructs a new exception with no detail message.
+     */
+    public InputSizeMissmatchException() {
+        super();
+    }
 }

--- a/src/CNN/Node.java
+++ b/src/CNN/Node.java
@@ -32,6 +32,9 @@ public class Node {
      * and stores it for use during backpropagation.
      */
     public double forward(double[] input) {
+        if (input.length != weights.length) {
+            throw new InputSizeMissmatchException(weights.length, input.length);
+        }
         double sum = bias;
         for (int i = 0; i < weights.length; i++) {
             sum += weights[i] * input[i];
@@ -48,6 +51,9 @@ public class Node {
      * @param learningRate step size for gradient descent
      */
     public void backward(double[] input, double delta, double learningRate) {
+        if (input.length != weights.length) {
+            throw new InputSizeMissmatchException(weights.length, input.length);
+        }
         for (int i = 0; i < weights.length; i++) {
             weights[i] -= learningRate * delta * input[i];
         }


### PR DESCRIPTION
## Summary
- add `InputSizeMissmatchException` implementation
- validate input size in `Node.forward` and `Node.backward`

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_685e268d64088327bfc727f849132ab7