### PR TITLE
Add GUI digit dataset creator and loader

### DIFF
--- a/src/TestModel/DigitDatasetLoader.java
+++ b/src/TestModel/DigitDatasetLoader.java
@@ -1,0 +1,59 @@
+package TestModel;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * Utility class to load digit images stored as text files.
+ * Files should be placed under a directory named by the digit label
+ * (e.g. data/6/image_123.txt). Each text file must contain 256 lines of
+ * space separated 0/1 values representing pixel intensities.
+ */
+public class DigitDatasetLoader {
+    public static class Data {
+        public final double[][][][] images; // [sample][channel][h][w]
+        public final double[][][][] labels; // [sample][1][1][10]
+        public Data(double[][][][] i, double[][][][] l) {
+            images = i; labels = l;
+        }
+    }
+
+    public static Data load(String root) throws IOException {
+        List<double[][][]> imgs = new ArrayList<>();
+        List<double[][][]> labs = new ArrayList<>();
+        for (int label = 0; label <= 9; label++) {
+            File dir = new File(root, Integer.toString(label));
+            if (!dir.isDirectory()) continue;
+            File[] files = dir.listFiles();
+            if (files == null) continue;
+            for (File f : files) {
+                if (!f.isFile()) continue;
+                double[][][] img = readImage(f);
+                imgs.add(img);
+                double[][][] lab = new double[1][1][10];
+                for (int i = 0; i < 10; i++) lab[0][0][i] = (i == label) ? 1.0 : 0.0;
+                labs.add(lab);
+            }
+        }
+        int n = imgs.size();
+        double[][][][] images = new double[n][1][256][256];
+        double[][][][] labels = new double[n][1][1][10];
+        for (int i = 0; i < n; i++) {
+            images[i] = imgs.get(i);
+            labels[i] = labs.get(i);
+        }
+        return new Data(images, labels);
+    }
+
+    private static double[][][] readImage(File file) throws IOException {
+        List<String> lines = java.nio.file.Files.readAllLines(file.toPath());
+        double[][][] out = new double[1][256][256];
+        for (int y = 0; y < 256 && y < lines.size(); y++) {
+            String[] tokens = lines.get(y).trim().split("\\s+");
+            for (int x = 0; x < 256 && x < tokens.length; x++) {
+                out[0][y][x] = Double.parseDouble(tokens[x]);
+            }
+        }
+        return out;
+    }
+}

--- a/src/TestModel/DigitDrawingTool.java
+++ b/src/TestModel/DigitDrawingTool.java
@@ -1,0 +1,113 @@
+package TestModel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+
+/**
+ * Simple GUI to create 256x256 digit images for training.
+ * The drawn image is saved as a text file containing 0s and 1s
+ * where 1 represents a black pixel. Images are stored in a
+ * directory named after the selected digit label.
+ */
+public class DigitDrawingTool extends JFrame {
+    private static final int SIZE = 256;
+    private final BufferedImage canvas;
+    private final JPanel canvasPanel;
+    private final ButtonGroup group;
+    private final String dataDir = "data";
+
+    public DigitDrawingTool() {
+        super("Digit Drawing Tool");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setLayout(new BorderLayout());
+
+        canvas = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_BYTE_BINARY);
+        clearCanvas();
+
+        canvasPanel = new JPanel() {
+            @Override
+            protected void paintComponent(Graphics g) {
+                super.paintComponent(g);
+                g.drawImage(canvas, 0, 0, null);
+            }
+        };
+        canvasPanel.setPreferredSize(new Dimension(SIZE, SIZE));
+        canvasPanel.addMouseMotionListener(new MouseMotionAdapter() {
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                Graphics2D g2 = canvas.createGraphics();
+                g2.setColor(Color.BLACK);
+                int x = e.getX();
+                int y = e.getY();
+                g2.fillOval(x, y, 8, 8);
+                g2.dispose();
+                canvasPanel.repaint();
+            }
+        });
+        add(canvasPanel, BorderLayout.CENTER);
+
+        JPanel controls = new JPanel();
+        group = new ButtonGroup();
+        for (int i = 0; i < 10; i++) {
+            JRadioButton btn = new JRadioButton(Integer.toString(i));
+            btn.setActionCommand(Integer.toString(i));
+            group.add(btn);
+            controls.add(btn);
+        }
+
+        JButton save = new JButton("Save");
+        save.addActionListener(e -> saveImage());
+        controls.add(save);
+
+        JButton clear = new JButton("Clear");
+        clear.addActionListener(e -> clearCanvas());
+        controls.add(clear);
+
+        add(controls, BorderLayout.SOUTH);
+        pack();
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    private void clearCanvas() {
+        Graphics2D g = canvas.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, SIZE, SIZE);
+        g.dispose();
+        if (canvasPanel != null) canvasPanel.repaint();
+    }
+
+    private void saveImage() {
+        if (group.getSelection() == null) {
+            JOptionPane.showMessageDialog(this, "Select a digit label first.");
+            return;
+        }
+        String label = group.getSelection().getActionCommand();
+        File dir = new File(dataDir, label);
+        dir.mkdirs();
+        File file = new File(dir, "image_" + System.currentTimeMillis() + ".txt");
+
+        try (PrintWriter pw = new PrintWriter(new FileWriter(file))) {
+            for (int y = 0; y < SIZE; y++) {
+                for (int x = 0; x < SIZE; x++) {
+                    int rgb = canvas.getRGB(x, y) & 0xFFFFFF;
+                    int val = (rgb == 0x000000) ? 1 : 0;
+                    pw.print(val);
+                    if (x < SIZE - 1) pw.print(' ');
+                }
+                pw.println();
+            }
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(this, "Failed to save image: " + ex.getMessage());
+            return;
+        }
+        clearCanvas();
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(DigitDrawingTool::new);
+    }
+}

--- a/src/TestModel/TrainDigits.java
+++ b/src/TestModel/TrainDigits.java
@@ -1,0 +1,34 @@
+package TestModel;
+
+import CNN.*;
+import java.io.IOException;
+
+/**
+ * Example program that loads digit images from labeled directories and
+ * trains a simple convolutional neural network.
+ */
+public class TrainDigits {
+    public static void main(String[] args) throws IOException {
+        // Load dataset
+        DigitDatasetLoader.Data data = DigitDatasetLoader.load("data");
+
+        Convolution2D conv = new Convolution2D(
+                3,
+                new int[]{1, 4, 16},
+                32,
+                3,
+                new int[]{1, 1, 1},
+                2,
+                new ReLU());
+
+        Classification model = new Classification(
+                32,
+                2,
+                new int[]{32, 16},
+                10,
+                new ReLU());
+
+        ConvolutionNeuralNetwork net = new ConvolutionNeuralNetwork(conv, model);
+        net.learning(data.images, data.labels);
+    }
+}


### PR DESCRIPTION
## Summary
- add `DigitDrawingTool` GUI to draw 256x256 digits and save them to label folders
- add `DigitDatasetLoader` for loading digit text files as training data
- add `TrainDigits` example using the loader and CNN for training

## Testing
- `javac -d bin src/CNN/*.java src/TestModel/DigitDatasetLoader.java src/TestModel/DigitDrawingTool.java src/TestModel/TrainDigits.java`


------
https://chatgpt.com/codex/tasks/task_e_68600e5d75f08327b7c909dc20514434