### PR TITLE
Implement backward propagation for CNN components

### DIFF
--- a/src/CNN/Classification.java
+++ b/src/CNN/Classification.java
@@ -72,12 +72,21 @@ public class Classification implements Model{
 		return softmax(lastLogits);
 	}
 	
-	public double[] backward(double[] input) {
-		double[] out = input;
-		return out;
-	}
+        public double[] backward(double[] input) {
+                double learningRate = 0.01;
+                double[] probs = softmax(lastLogits);
+                double[] delta = new double[probs.length];
+                for(int i = 0; i < probs.length && i < input.length; i++) {
+                        delta[i] = probs[i] - input[i];
+                }
+
+                double[] grad = outputLayer.backward(layerInputs[hiddenLayers.length], delta, learningRate);
+                for(int i = hiddenLayers.length - 1; i >= 0; i--) {
+                        grad = hiddenLayers[i].backward(layerInputs[i], grad, learningRate);
+                }
+                return grad;
+        }
 	
-	//TODO implement backward
 	
 	/**
 	 * Computes cross entropy between a predicted probability distribution and

--- a/src/CNN/Convolution2D.java
+++ b/src/CNN/Convolution2D.java
@@ -76,7 +76,7 @@ public class Convolution2D {
 		return out;
 	}
 	
-	public double[] globalPooling(double[][][] input){
+        public double[] globalPooling(double[][][] input){
 		int depth = input.length;
 		int height = input[0].length;
 		int width = input[0][0].length;
@@ -93,8 +93,73 @@ public class Convolution2D {
 			out[d] = sum / (height * width);
 		}
 		
-		return out;
-	}
-	
-	//TODO implement backward, poolingBackward, globalPoolingBackward
+                return out;
+        }
+
+        /**
+         * Performs the backward pass through the convolution stack.
+         *
+         * @param gradOutput gradient with respect to the final pooled output
+         * @return gradient with respect to the original input
+         */
+        public double[][][] backward(double[] gradOutput) {
+                double learningRate = 0.01;
+
+                // Gradient w.r.t. output of the last convolution layer
+                double[][][] grad = globalPoolingBackward(gradOutput);
+
+                int last = convolutionLayers.length - 1;
+                grad = convolutionLayers[last].backward(lastInputs[last], grad, learningRate);
+
+                for (int i = last - 1; i >= 0; i--) {
+                        grad = poolingBackward(grad, lastActivations[i]);
+                        grad = convolutionLayers[i].backward(lastInputs[i], grad, learningRate);
+                }
+
+                return grad;
+        }
+
+        private double[][][] poolingBackward(double[][][] grad, double[][][] beforePool) {
+                int depth = beforePool.length;
+                int height = beforePool[0].length;
+                int width = beforePool[0][0].length;
+                double[][][] gradInput = new double[depth][height][width];
+                int outHeight = grad[0].length;
+                int outWidth = grad[0][0].length;
+
+                for (int d = 0; d < depth; d++) {
+                        for (int y = 0; y < outHeight; y += stride) {
+                                for (int x = 0; x < outWidth; x += stride) {
+                                        double delta = grad[d][y][x] / (kernel * kernel);
+                                        for (int i = 0; i < kernel; i++) {
+                                                for (int j = 0; j < kernel; j++) {
+                                                        int inY = y + i;
+                                                        int inX = x + j;
+                                                        if (inY >= 0 && inY < height && inX >= 0 && inX < width) {
+                                                                gradInput[d][inY][inX] += delta;
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                }
+                return gradInput;
+        }
+
+        private double[][][] globalPoolingBackward(double[] grad) {
+                int depth = lastConvOutput.length;
+                int height = lastConvOutput[0].length;
+                int width = lastConvOutput[0][0].length;
+                double[][][] gradInput = new double[depth][height][width];
+
+                for (int d = 0; d < depth && d < grad.length; d++) {
+                        double delta = grad[d] / (height * width);
+                        for (int y = 0; y < height; y++) {
+                                for (int x = 0; x < width; x++) {
+                                        gradInput[d][y][x] = delta;
+                                }
+                        }
+                }
+                return gradInput;
+        }
 }

--- a/src/CNN/Convolution2DLayer.java
+++ b/src/CNN/Convolution2DLayer.java
@@ -98,14 +98,53 @@ public class Convolution2DLayer {
 	 * Applies the configured activation function element-wise to the supplied
 	 * tensor.
 	 */
-	public double[][][] activation(double[][][] input) {
-		double[][][] out = new double[input.length][input[0].length][input[0][0].length];
-		for (int f = 0; f < input.length; f++) {
-			for (int y = 0; y < input[0].length; y++) {
-			}
-		}
-		return out;
-	}
-	
-	//TODO implement backward
+        public double[][][] activation(double[][][] input) {
+                double[][][] out = new double[input.length][input[0].length][input[0][0].length];
+                for (int f = 0; f < input.length; f++) {
+                        out[f] = activation.activate2D(input[f]);
+                }
+                return out;
+        }
+
+        /**
+         * Backward pass for this convolution layer.
+         *
+         * @param input       input tensor used during the forward pass
+         * @param gradOutput  gradient with respect to the activated output
+         * @param lr          learning rate for parameter updates
+         * @return gradient with respect to the input tensor
+         */
+        public double[][][] backward(double[][][] input, double[][][] gradOutput, double lr) {
+                int depth = input.length;
+                int height = input[0].length;
+                int width = input[0][0].length;
+
+                int outHeight = gradOutput[0].length;
+                int outWidth = gradOutput[0][0].length;
+
+                double[][][] gradInput = new double[depth][height][width];
+
+                for (int f = 0; f < filters.length; f++) {
+                        double[][] actDeriv = activation.derivative2D(lastZ[f]);
+                        for (int y = 0; y < outHeight; y += stride) {
+                                for (int x = 0; x < outWidth; x += stride) {
+                                        double delta = gradOutput[f][y][x] * actDeriv[y][x];
+                                        biases[f] -= lr * delta;
+                                        for (int d = 0; d < depth; d++) {
+                                                for (int i = 0; i < kernel; i++) {
+                                                        for (int j = 0; j < kernel; j++) {
+                                                                int inY = y + i;
+                                                                int inX = x + j;
+                                                                if (inY >= 0 && inY < height && inX >= 0 && inX < width) {
+                                                                        gradInput[d][inY][inX] += filters[f][d][i][j] * delta;
+                                                                        filters[f][d][i][j] -= lr * input[d][inY][inX] * delta;
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                }
+                        }
+                }
+                return gradInput;
+        }
 }

--- a/src/CNN/Layer.java
+++ b/src/CNN/Layer.java
@@ -55,6 +55,39 @@ public class Layer {
 		return out;
 	}
 	
-	//TODO implement backward
+        /**
+         * Backward pass for the layer.
+         *
+         * @param input       the input vector that was fed to this layer in the forward pass
+         * @param gradOutput  gradient with respect to the activated output of this layer
+         * @param lr          learning rate used for parameter updates
+         * @return gradient with respect to the input vector
+         */
+        public double[] backward(double[] input, double[] gradOutput, double lr) {
+                if (gradOutput.length != nodes.length) {
+                        throw new InputSizeMissmatchException(nodes.length, gradOutput.length);
+                }
+
+                // Compute derivative of activation for each node
+                double[] z = new double[nodes.length];
+                for (int i = 0; i < nodes.length; i++) {
+                        z[i] = nodes[i].getLastZ();
+                }
+                double[] actDeriv = activation.derivative(z);
+
+                double[] delta = new double[nodes.length];
+                for (int i = 0; i < nodes.length; i++) {
+                        delta[i] = gradOutput[i] * actDeriv[i];
+                }
+
+                double[] gradInput = new double[input.length];
+                for (int i = 0; i < nodes.length; i++) {
+                        double[] nodeGrad = nodes[i].backward(input, delta[i], lr);
+                        for (int j = 0; j < gradInput.length; j++) {
+                                gradInput[j] += nodeGrad[j];
+                        }
+                }
+                return gradInput;
+        }
 }
 

--- a/src/CNN/Node.java
+++ b/src/CNN/Node.java
@@ -43,7 +43,31 @@ public class Node {
 		return sum;
 	}
 	
-	//TODO implement backward
+        /**
+         * Backward pass for this node. Updates the weights and bias using
+         * the provided learning rate and returns the gradient with respect
+         * to the node inputs.
+         *
+         * @param input  the inputs that were used during the forward pass
+         * @param delta  gradient of the loss with respect to this node's output
+         * @param lr     learning rate for the weight update
+         * @return gradient with respect to the input vector
+         */
+        public double[] backward(double[] input, double delta, double lr) {
+                if (input.length != weights.length) {
+                        throw new InputSizeMissmatchException(weights.length, input.length);
+                }
+
+                double[] gradInput = new double[weights.length];
+
+                for (int i = 0; i < weights.length; i++) {
+                        gradInput[i] = weights[i] * delta;
+                        // SGD weight update
+                        weights[i] -= lr * delta * input[i];
+                }
+                bias -= lr * delta;
+                return gradInput;
+        }
 	
 	public double getLastZ() {
 		return lastZ;

--- a/src/CNN/ReLU.java
+++ b/src/CNN/ReLU.java
@@ -36,12 +36,12 @@ public class ReLU implements ActivationFunc {
 	
 	@Override
 	public double[][] derivative2D(double[][] x){
-		double[][] out = new double[x.length][x[0].length];
-		for(int i = 0; i<x.length; i++) {
-			for(int j = 0; j<x[0].length; i++) {
-				out[i][j] = x[i][j] > 0.0 ? 1.0 : 0.0;			
-			}
-		}
-		return out;
-	}
+                double[][] out = new double[x.length][x[0].length];
+                for(int i = 0; i<x.length; i++) {
+                        for(int j = 0; j<x[0].length; j++) {
+                                out[i][j] = x[i][j] > 0.0 ? 1.0 : 0.0;
+                        }
+                }
+                return out;
+        }
 }

--- a/src/CNN/Regression.java
+++ b/src/CNN/Regression.java
@@ -45,11 +45,20 @@ public class Regression implements Model {
 		return lastOutput;
 	}
 	
-	public double[] backward(double[] input) {
-		return new double[1];
-	}
+        public double[] backward(double[] input) {
+                double learningRate = 0.01;
+                double[] delta = new double[lastOutput.length];
+                for(int i = 0; i < lastOutput.length; i++) {
+                        delta[i] = lastOutput[i] - input[i];
+                }
+
+                double[] grad = outputLayer.backward(layerInputs[hiddenLayer.length], delta, learningRate);
+                for(int i = hiddenLayer.length - 1; i >= 0; i--) {
+                        grad = hiddenLayer[i].backward(layerInputs[i], grad, learningRate);
+                }
+                return grad;
+        }
 	
-	//TODO implement backward
 	
 	/**
 	 * Computes the mean squared error between predicted and target values.

--- a/src/CNN/Sigmoid.java
+++ b/src/CNN/Sigmoid.java
@@ -16,14 +16,14 @@ public class Sigmoid implements ActivationFunc {
 	
 	@Override
 	public double[][] activate2D(double[][] x){
-		double[][] out = new double[x.length][x[0].length];
-		for(int i = 0; i<x.length; i++) {
-			for(int j = 0; j<x[0].length; i++) {
-				out[i][j] = 1.0 / (1.0 + Math.exp(-x[i][j]));			
-			}
-		}
-		return out;
-	}
+                double[][] out = new double[x.length][x[0].length];
+                for(int i = 0; i<x.length; i++) {
+                        for(int j = 0; j<x[0].length; j++) {
+                                out[i][j] = 1.0 / (1.0 + Math.exp(-x[i][j]));
+                        }
+                }
+                return out;
+        }
 	
 	@Override
 	public double[] derivative(double[] x) {
@@ -37,13 +37,13 @@ public class Sigmoid implements ActivationFunc {
 	
 	@Override
 	public double[][] derivative2D(double[][] x){
-		double[][] out = new double[x.length][x[0].length];
-		double[][] y = activate2D(x);
-		for(int i = 0; i<x.length; i++) {
-			for(int j = 0; j<x[0].length; i++) {
-				out[i][j] = y[i][j] * (1.0 - y[i][j]);			
-			}
-		}
-		return out;
-	}
+                double[][] out = new double[x.length][x[0].length];
+                double[][] y = activate2D(x);
+                for(int i = 0; i<x.length; i++) {
+                        for(int j = 0; j<x[0].length; j++) {
+                                out[i][j] = y[i][j] * (1.0 - y[i][j]);
+                        }
+                }
+                return out;
+        }
 }


### PR DESCRIPTION
## Summary
- add backpropagation logic to `Node` and `Layer`
- fix loops in `ReLU` and `Sigmoid` activation functions
- implement activation and backward pass for `Convolution2DLayer`
- implement backpropagation methods for `Regression` and `Classification`
- add backward support to `Convolution2D`

## Testing
- `javac @sources_cnn.txt && echo compiled`

------
https://chatgpt.com/codex/tasks/task_e_6860ca3e13a08327b5641df57d9d8022